### PR TITLE
Fix gender in README features line

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Aplicació d'escriptori per convertir fotos d'esbossos a SVG amb presets educati
 - Converteix fotos d'esbossos a SVG.
 - Dos modes de vectorització: Contorn omplert (outline) i Traç únic (centerline).
 - Presets per a Fusion 360, làser, plotter, brodat.
-- Robust, simple d'instal·lar i funciona sense internet.
+- Robusta, simple d'instal·lar i funciona sense internet.
 - Multiplataforma (Linux, Windows).
 
 ## Desenvolupament


### PR DESCRIPTION
## Summary
- adjust README feature description to use "Robusta" for consistent feminine gender
- review rest of README for similar gender mismatches

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6b3ccbbd08333a84630c2b333d657