### PR TITLE
Clarify preset default behavior

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -113,7 +113,20 @@ def save_config(current_settings):
         print(f"Error guardant la configuració: {e}")
 
 def get_preset_settings(preset_name):
-    """Retorna els paràmetres d'un preset donat."""
+    """Retorna els paràmetres d'un preset donat.
+
+    Si el nom del preset no es troba, es retorna una còpia de
+    ``DEFAULT_STANDARD_SETTINGS``.
+
+    Exemples:
+        >>> get_preset_settings("Làser - Tall (CUT)")["mode_var"]
+        'outline'
+        >>> cfg = get_preset_settings("Preset Inexistent")
+        >>> cfg == DEFAULT_STANDARD_SETTINGS
+        True
+        >>> cfg is DEFAULT_STANDARD_SETTINGS
+        False
+    """
     if preset_name in PRESETS:
         return PRESETS[preset_name]
     return DEFAULT_STANDARD_SETTINGS.copy()


### PR DESCRIPTION
## Summary
- clarify in `get_preset_settings` docstring that unknown presets return a copy of default settings
- add doctest-style examples demonstrating preset lookup and fallback

## Testing
- `python -m py_compile config_manager.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6b3e2b06083338209a721a581584e