### PR TITLE
Fix scale preset mapping for SVG scaling

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -108,7 +108,20 @@ def save_config(current_settings):
         print(f"Error guardant la configuració: {e}")
 
 def get_preset_settings(preset_name):
-    """Retorna els paràmetres d'un preset donat."""
+    """Retorna els paràmetres d'un preset donat.
+
+    Si el nom del preset no es troba, es retorna una còpia de
+    ``DEFAULT_STANDARD_SETTINGS``.
+
+    Exemples:
+        >>> get_preset_settings("Làser - Tall (CUT)")["mode_var"]
+        'outline'
+        >>> cfg = get_preset_settings("Preset Inexistent")
+        >>> cfg == DEFAULT_STANDARD_SETTINGS
+        True
+        >>> cfg is DEFAULT_STANDARD_SETTINGS
+        False
+    """
     if preset_name in PRESETS:
         return PRESETS[preset_name]
     return DEFAULT_STANDARD_SETTINGS.copy()

--- a/main.py
+++ b/main.py
@@ -77,10 +77,18 @@ class Sketch2SVGApp:
 
         self.dpi_var = tk.IntVar()
         self.scale_preset_var = tk.StringVar()
-        self.scale_preset_options = ["Cap", "Alçada 20mm", "Alçada 25mm", "Alçada 30mm", "Amplada 20mm", "Amplada 25mm", "Amplada 30mm"]
+        self.scale_preset_options = [
+            "Cap", "Alçada 20mm", "Alçada 25mm", "Alçada 30mm",
+            "Amplada 20mm", "Amplada 25mm", "Amplada 30mm"
+        ]
         self.scale_preset_values = {
-            "none": None, "Alçada 20mm": ("height", 20), "Alçada 25mm": ("height", 25), "Alçada 30mm": ("height", 30),
-            "Amplada 20mm": ("width", 20), "Amplada 25mm": ("width", 25), "Amplada 30mm": ("width", 30)
+            "Cap": None,
+            "Alçada 20mm": ("height", 20),
+            "Alçada 25mm": ("height", 25),
+            "Alçada 30mm": ("height", 30),
+            "Amplada 20mm": ("width", 20),
+            "Amplada 25mm": ("width", 25),
+            "Amplada 30mm": ("width", 30),
         }
 
         self.canvas = tk.Canvas(master, bg=COLORS["Nexe_50"], highlightthickness=0)
@@ -680,7 +688,7 @@ class Sketch2SVGApp:
             img_height, img_width = binarized_image_np.shape
             stroke_width_mm = self.stroke_mm_var.get()
             dpi = self.dpi_var.get()
-            scale_preset_tuple = self.scale_preset_values.get(self.scale_preset_var.get(), (None, None))
+            scale_preset_tuple = self.scale_preset_values.get(self.scale_preset_var.get())
             
             target_width_mm = None
             target_height_mm = None
@@ -931,7 +939,7 @@ class Sketch2SVGApp:
                 
                 if success_svg:
                     dpi = self.dpi_var.get()
-                    scale_preset_tuple = self.scale_preset_values.get(self.scale_preset_var.get(), (None, None))
+                    scale_preset_tuple = self.scale_preset_values.get(self.scale_preset_var.get())
                     
                     target_width_mm = None
                     target_height_mm = None


### PR DESCRIPTION
## Summary
- correct scale preset dictionary to map "Cap" option
- simplify scale preset lookup when vectorizing/ exporting
- clarify `get_preset_settings` with examples and default copy

## Testing
- `python -m py_compile main.py config_manager.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'PIL'; `pip install pillow` failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b2b397c88333a01433b0007f9461