### PR TITLE
Rename app to Trama Maker Conversor 2d

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sketch2SVG
+# Trama Maker Conversor 2d
 
 Aplicació d'escriptori per convertir fotos d'esbossos a SVG amb presets educatius.
 

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-CONFIG_FILE = os.path.join(os.path.expanduser("~"), ".sketch2svgrc.json")
+CONFIG_FILE = os.path.join(os.path.expanduser("~"), ".trama_maker_conversor_2drc.json")
 
 DEFAULT_STANDARD_SETTINGS = {
     "mode_var": "outline",

--- a/main.py
+++ b/main.py
@@ -44,10 +44,10 @@ FONTS = {
     "UI_Tooltip": ("Inter", 8, "normal")
 }
 
-class Sketch2SVGApp:
+class TramaMakerConversor2dApp:
     def __init__(self, master):
         self.master = master
-        master.title("Sketch2SVG")
+        master.title("Trama Maker Conversor 2d")
         master.geometry("1000x700")
         master.configure(bg=COLORS["Nexe_50"])
 
@@ -122,7 +122,7 @@ class Sketch2SVGApp:
         self.control_frame.grid_columnconfigure(2, weight=0, minsize=50)
 
 
-        ttk.Label(self.control_frame, text="Controls de Sketch2SVG", font=FONTS["Title"], foreground=COLORS["Nexe_800"]).grid(row=0, column=0, columnspan=3, pady=(0, 20), sticky="ew")
+        ttk.Label(self.control_frame, text="Controls de Trama Maker Conversor 2d", font=FONTS["Title"], foreground=COLORS["Nexe_800"]).grid(row=0, column=0, columnspan=3, pady=(0, 20), sticky="ew")
 
         self.add_section_title(self.control_frame, "Configuració General", 1)
 
@@ -1256,5 +1256,5 @@ if __name__ == "__main__":
               background=[('active', COLORS["Nexe_200"])])
 
 
-    app = Sketch2SVGApp(root)
+    app = TramaMakerConversor2dApp(root)
     root.mainloop()

--- a/test_presets.py
+++ b/test_presets.py
@@ -1,9 +1,9 @@
 import unittest
 import config_manager
 try:
-    from main import Sketch2SVGApp
+    from main import TramaMakerConversor2dApp
 except ModuleNotFoundError:  # Dependencies for main (e.g., Pillow) may be missing in test env
-    Sketch2SVGApp = None
+    TramaMakerConversor2dApp = None
 
 class DummyVar:
     def __init__(self, value):
@@ -31,7 +31,7 @@ class DummyApp:
         pass
 
 class TestApplyPreset(unittest.TestCase):
-    @unittest.skipUnless(Sketch2SVGApp is not None, "Sketch2SVGApp or dependencies not available")
+    @unittest.skipUnless(TramaMakerConversor2dApp is not None, "TramaMakerConversor2dApp or dependencies not available")
     def test_presets_reset_defaults(self):
         defaults = config_manager.DEFAULT_STANDARD_SETTINGS
         for preset_name in config_manager.PRESETS.keys():
@@ -46,7 +46,7 @@ class TestApplyPreset(unittest.TestCase):
                 else:
                     var.set("CHANGED")
             # Apply preset
-            Sketch2SVGApp.apply_preset(app, preset_name)
+            TramaMakerConversor2dApp.apply_preset(app, preset_name)
             expected = {**defaults, **config_manager.PRESETS[preset_name]}
             for key, expected_value in expected.items():
                 self.assertEqual(getattr(app, key).get(), expected_value, f"{preset_name} did not reset {key}")

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -33,12 +33,12 @@ _stub_module('svg.path', {
 svg_module.path = sys.modules['svg.path']
 
 import config_manager
-from main import Sketch2SVGApp
+from main import TramaMakerConversor2dApp
 
 
 def create_app_without_gui():
     tcl = tk.Tcl()
-    app = Sketch2SVGApp.__new__(Sketch2SVGApp)
+    app = TramaMakerConversor2dApp.__new__(TramaMakerConversor2dApp)
     app.mode_var = tk.StringVar(master=tcl)
     app.batch_aggressive_var = tk.BooleanVar(master=tcl)
     app.preset_profile_var = tk.StringVar(master=tcl)


### PR DESCRIPTION
## Summary
- rename GUI application and class to **Trama Maker Conversor 2d**
- update config file path and documentation
- adjust tests and imports for new class name

## Testing
- `pytest tests/test_presets.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6c004e04c833397791c98512a5af8